### PR TITLE
Fix FriendlyWrt rootfs owner and group

### DIFF
--- a/.github/workflows/r2s_lienol_from_lean.yml
+++ b/.github/workflows/r2s_lienol_from_lean.yml
@@ -158,6 +158,16 @@ jobs:
           sed -i 's/set -eu/set -u/' scripts/mk-friendlywrt.sh
           ./build.sh nanopi_r2s.mk
 
+      - name: Fix FriendlyWrt rootfs owner and group
+        run: |
+          sudo losetup -o 100663296 /dev/loop99 friendlywrt-rk3328/out/*.img
+          sudo rm -rf /mnt/friendlywrt-tmp
+          sudo mkdir -p /mnt/friendlywrt-tmp
+          sudo mount /dev/loop99 /mnt/friendlywrt-tmp
+          sudo chown -R root:root /mnt/friendlywrt-tmp
+          sudo umount /mnt/friendlywrt-tmp
+          sudo losetup -d /dev/loop99
+
       - name: Zip Files
         run: |
           gzip friendlywrt-rk3328/out/*.img


### PR DESCRIPTION
友善的官方脚本编译出来整个 rootfs 的用户组都是 1001:1001 会导致很多权限问题！
在[这里](https://github.com/fanck0605/friendlywrt-nanopi_r2s/actions)测试过了没问题。