### PR TITLE
Update patch_kernel_5.4.sh

### DIFF
--- a/patch_kernel_5.4.sh
+++ b/patch_kernel_5.4.sh
@@ -7,6 +7,7 @@ cd ../
 git clone https://github.com/openwrt/openwrt && cd openwrt/
 #git checkout 4e0c54bc5bc8381e031af5147b66b4dadeecc626
 rm target/linux/generic/pending-5.4/403-mtd-hook-mtdsplit-to-Kbuild.patch
+rm target/linux/generic/pending-5.4/184-USB-serial-option-add-Wistron-Neweb-D19Q1.patch
 rm target/linux/generic/hack-5.4/700-swconfig_switch_drivers.patch
 ./scripts/patch-kernel.sh ../kernel target/linux/generic/backport-5.4
 ./scripts/patch-kernel.sh ../kernel target/linux/generic/pending-5.4

--- a/patch_kernel_5.4.sh
+++ b/patch_kernel_5.4.sh
@@ -6,8 +6,8 @@ git apply RK3328-enable-1512mhz-opp.patch
 cd ../
 git clone https://github.com/openwrt/openwrt && cd openwrt/
 #git checkout 4e0c54bc5bc8381e031af5147b66b4dadeecc626
-rm target/linux/generic/pending-5.4/403-mtd-hook-mtdsplit-to-Kbuild.patch
 rm target/linux/generic/pending-5.4/184-USB-serial-option-add-Wistron-Neweb-D19Q1.patch
+rm target/linux/generic/pending-5.4/403-mtd-hook-mtdsplit-to-Kbuild.patch
 rm target/linux/generic/hack-5.4/700-swconfig_switch_drivers.patch
 ./scripts/patch-kernel.sh ../kernel target/linux/generic/backport-5.4
 ./scripts/patch-kernel.sh ../kernel target/linux/generic/pending-5.4


### PR DESCRIPTION
fix patch error
openwrt官方代码库在target/linux/generic/pending-5.4下增加了184-USB-serial-option-add-Wistron-Neweb-D19Q1.patch, 加入对Wistron-Neweb-D19Q1的支持,编译会报错, 修改了一下patch脚本直接rm掉了, 应该是用不着的