### PR TITLE
revert all mac80211 upgrade

### DIFF
--- a/.github/workflows/r2s_lean_minimal.yml
+++ b/.github/workflows/r2s_lean_minimal.yml
@@ -124,14 +124,13 @@ jobs:
           ' >> configs/config_rk3328
           cd friendlywrt
           git config --local user.email "action@github.com" && git config --local user.name "GitHub Action"
-          git remote add upstream https://github.com/coolsnowwolf/lede && git fetch upstream
-          git rebase adc1a9a3676b8d7be1b48b5aed185a94d8e42728^ --onto upstream/master -X theirs
-          git revert --no-edit b65f1ebf0089a2fa0d3e1ad30efc21385a013139
-          git revert --no-edit 2c37fa71f93d150eb67bffdc5bdac8abf5354b16
-          git revert --no-edit 23378ed9a481dc73923f5bfa81637a1a8056882d
-          git revert --no-edit 4787dbaf3cad44b374b660cc0fef9386963e6795
-          git revert --no-edit 463b6ac0508de4788a6e41335471ced0a255e1cd
-          git revert --no-edit 8faac30089ce616940b3e96c4f4d900aeb6b9fcb
+          git remote add upstream https://github.com/coolsnowwolf/lede && git fetch upstream master
+          git checkout -b lean upstream/master
+          git reset 0a395d6fd6c38c554709197ae3cd6315f143cd7a -- package/kernel/mac80211
+          git commit -m "Revert upgrade mac80211"
+          git reset --hard
+          git checkout master-v19.07.1
+          git rebase adc1a9a3676b8d7be1b48b5aed185a94d8e42728^ --onto lean -X theirs
           rm target/linux/rockchip-rk3328/patches-4.14/0001-net-thunderx-workaround-BGX-TX-Underflow-issue.patch
           sed -i '/ipv6/,+3d' package/base-files/files/root/setup.sh
           git checkout upstream/master -- feeds.conf.default

--- a/.github/workflows/r2s_lean_minimal.yml
+++ b/.github/workflows/r2s_lean_minimal.yml
@@ -124,13 +124,9 @@ jobs:
           ' >> configs/config_rk3328
           cd friendlywrt
           git config --local user.email "action@github.com" && git config --local user.name "GitHub Action"
-          git remote add upstream https://github.com/coolsnowwolf/lede && git fetch upstream master
-          git checkout -b lean upstream/master
+          git remote add upstream https://github.com/coolsnowwolf/lede && git fetch upstream
+          git rebase adc1a9a3676b8d7be1b48b5aed185a94d8e42728^ --onto upstream/master -X theirs
           git reset 0a395d6fd6c38c554709197ae3cd6315f143cd7a -- package/kernel/mac80211
-          git commit -m "Revert upgrade mac80211"
-          git reset --hard
-          git checkout master-v19.07.1
-          git rebase adc1a9a3676b8d7be1b48b5aed185a94d8e42728^ --onto lean -X theirs
           rm target/linux/rockchip-rk3328/patches-4.14/0001-net-thunderx-workaround-BGX-TX-Underflow-issue.patch
           sed -i '/ipv6/,+3d' package/base-files/files/root/setup.sh
           git checkout upstream/master -- feeds.conf.default


### PR DESCRIPTION
这样就可以省去很多 revert 了，一劳永逸
这边要先 reset 再 rebase 因为友善也做了修改，操作不当会把友善的修改一起 reset 掉