### PR TITLE
对文件添加MD5验证

### DIFF
--- a/.github/workflows/r1s_lean.yml
+++ b/.github/workflows/r1s_lean.yml
@@ -127,6 +127,9 @@ jobs:
           mkdir -p ./artifact/
           mv friendlywrt-h5/out/*img* ./artifact/
           cp friendlywrt-h5/friendlywrt/.config ./artifact/
+          cd ./artifact/
+          md5sum *img* > md5sum.txt
+          cd ..
           zip -r artifact.zip ./artifact/
           release_tag="R1S-Lean-$(date +%Y-%m-%d)"
           echo "##[set-output name=release_tag;]$release_tag"

--- a/.github/workflows/r1s_lean_h3.yml
+++ b/.github/workflows/r1s_lean_h3.yml
@@ -132,6 +132,9 @@ jobs:
           mkdir -p ./artifact/
           mv friendlywrt-h3/out/*img* ./artifact/
           cp friendlywrt-h3/friendlywrt/.config ./artifact/
+          cd ./artifact/
+          md5sum *img* > md5sum.txt
+          cd ..
           zip -r artifact.zip ./artifact/
           release_tag="R1S-H3-$(date +%Y-%m-%d)"
           echo "##[set-output name=release_tag;]$release_tag"

--- a/.github/workflows/r1s_lienol.yml
+++ b/.github/workflows/r1s_lienol.yml
@@ -120,6 +120,9 @@ jobs:
           mkdir -p ./artifact/
           mv friendlywrt-h5/out/*img* ./artifact/
           cp friendlywrt-h5/friendlywrt/.config ./artifact/
+          cd ./artifact/
+          md5sum *img* > md5sum.txt
+          cd ..
           zip -r artifact.zip ./artifact/
           release_tag="R1S-Lienol-$(date +%Y-%m-%d)"
           echo "##[set-output name=release_tag;]$release_tag"

--- a/.github/workflows/r2s_lean.yml
+++ b/.github/workflows/r2s_lean.yml
@@ -113,6 +113,9 @@ jobs:
           mkdir -p ./artifact/
           mv friendlywrt-rk3328/out/*img* ./artifact/
           cp friendlywrt-rk3328/friendlywrt/.config ./artifact/
+          cd ./artifact/
+          md5sum *img* > md5sum.txt
+          cd ..
           zip -r artifact.zip ./artifact/
           release_tag="R2S-Lean-$(date +%Y-%m-%d)"
           echo "##[set-output name=release_tag;]$release_tag"

--- a/.github/workflows/r2s_lean_minimal.yml
+++ b/.github/workflows/r2s_lean_minimal.yml
@@ -199,6 +199,9 @@ jobs:
           mkdir -p ./artifact/
           mv friendlywrt-rk3328/out/*img* ./artifact/
           cp friendlywrt-rk3328/friendlywrt/.config ./artifact/
+          cd ./artifact/
+          md5sum *img* > md5sum.txt
+          cd ..
           zip -r artifact.zip ./artifact/
           #release_tag="R2S-Lean-$(date +%Y-%m-%d)-Minimal"
           release_tag="R2S-Minimal-$(date +%Y-%m-%d)"

--- a/.github/workflows/r2s_lienol.yml
+++ b/.github/workflows/r2s_lienol.yml
@@ -98,6 +98,9 @@ jobs:
           mkdir -p ./artifact/
           mv friendlywrt-rk3328/out/*img* ./artifact/
           cp friendlywrt-rk3328/friendlywrt/.config ./artifact/
+          cd ./artifact/
+          md5sum *img* > md5sum.txt
+          cd ..
           zip -r artifact.zip ./artifact/
           release_tag="R2S-Lienol-$(date +%Y-%m-%d)"
           echo "##[set-output name=release_tag;]$release_tag"

--- a/.github/workflows/r2s_lienol_from_lean.yml_
+++ b/.github/workflows/r2s_lienol_from_lean.yml_
@@ -171,6 +171,9 @@ jobs:
           mkdir -p ./artifact/
           mv friendlywrt-rk3328/out/*img* ./artifact/
           cp friendlywrt-rk3328/friendlywrt/.config ./artifact/
+          cd ./artifact/
+          md5sum *img* > md5sum.txt
+          cd ..
           zip -r artifact.zip ./artifact/
           release_tag="R2S-Minimal-$(date +%Y-%m-%d)"
           echo "##[set-output name=release_tag;]$release_tag"

--- a/.github/workflows/r2s_original.yml
+++ b/.github/workflows/r2s_original.yml
@@ -73,6 +73,9 @@ jobs:
           mkdir -p ./artifact/
           mv friendlywrt-rk3328/out/*img* ./artifact/
           cp friendlywrt-rk3328/friendlywrt/.config ./artifact/
+          cd ./artifact/
+          md5sum *img* > md5sum.txt
+          cd ..
       - name: Upload Artifact
         uses: actions/upload-artifact@master
         with:

--- a/scripts/autoupdate-usb.sh
+++ b/scripts/autoupdate-usb.sh
@@ -20,6 +20,12 @@ fi
 unzip R2S*.zip
 rm R2S*.zip
 if [ -f /mnt/mmcblk0p2/artifact/FriendlyWrt*.img.gz ]; then
+    cd /mnt/mmcblk0p2/artifact/
+    if [ `md5sum -c md5sum.txt|grep -c "OK"` -eq 0 ]; then
+        echo -e '\e[91m固件HASH值匹配失败，脚本退出\e[0m'
+		exit 1
+    fi
+    cd /mnt/mmcblk0p2
 	pv /mnt/mmcblk0p2/artifact/FriendlyWrt*.img.gz | gunzip -dc > FriendlyWrt.img
 	echo -e '\e[92m准备解压镜像文件\e[0m'
 fi

--- a/scripts/autoupdate.sh
+++ b/scripts/autoupdate.sh
@@ -18,6 +18,12 @@ fi
 unzip R2S*.zip
 rm R2S*.zip
 if [ -f /mnt/mmcblk0p2/artifact/FriendlyWrt*.img.gz ]; then
+    cd /mnt/mmcblk0p2/artifact/
+    if [ `md5sum -c md5sum.txt|grep -c "OK"` -eq 0 ]; then
+        echo -e '\e[91m固件HASH值匹配失败，脚本退出\e[0m'
+		exit 1
+    fi
+    cd /mnt/mmcblk0p2
 	pv /mnt/mmcblk0p2/artifact/FriendlyWrt*.img.gz | gunzip -dc > FriendlyWrt.img
 	echo -e '\e[92m准备解压镜像文件\e[0m'
 fi


### PR DESCRIPTION
添加MD5验证文件，并打包进压缩包中。

GitHub下载问题，文件又大，总担心出错。

因为是ROM所以谨慎点。

同时对更新脚本加入自动校验MD5。

