### PR TITLE
fix rtl8xxxcu problem

### DIFF
--- a/base_rk3328.seed
+++ b/base_rk3328.seed
@@ -23,7 +23,7 @@ CONFIG_PACKAGE_kmod-usb-net-rtl8150=y
 CONFIG_PACKAGE_kmod-usb-net-rtl8152=y
 CONFIG_PACKAGE_kmod-usb-net-rndis=y
 CONFIG_PACKAGE_kmod-usb-net-cdc-ether=y
-CONFIG_PACKAGE_kmod-rtl8xxxu=y
+CONFIG_PACKAGE_kmod-rtl8xxxcu=y
 CONFIG_PACKAGE_kmod-rtl8192cu=y
 
 CONFIG_PACKAGE_iw=y


### PR DESCRIPTION
我下载了最新的固件, 发现对于usb 无线网卡的支持可能有一些bug, 我的网卡是rtl8811cu, 插上去之后重启默认设置是有效的, 但是如果修改成 5Ghz (网卡是双频的), 就会驱动不起来, 我看了一下代码, 可能是作者大大这边漏了一一点