### PR TITLE
更新脚本添加qemu虚拟机判断

### DIFF
--- a/scripts/autoupdate.sh
+++ b/scripts/autoupdate.sh
@@ -18,7 +18,7 @@ chmod +x /tmp/truncate /tmp/ddnz
 
 board_id=$(cat /etc/board.json | jsonfilter -e '@["model"].id' | sed 's/friendly.*,nanopi-//;s/xunlong,orangepi-//;s/^r1s-h5$/r1s/;s/^r1$/r1s-h3/;s/^r1-plus$/r1p/')
 if [[ $board_id =~ .*qemu.* ]]; then
-    echo -e '\e[91m当前环境为qemu虚拟机，默认下载x86固件\e[0m'
+    echo -e '\e[91m当前环境为qemu虚拟机，默认下载x86固件，如需停止请按Ctrl+C\e[0m'
     board_id=x86
 fi
 mount -t tmpfs -o remount,size=850m tmpfs /tmp

--- a/scripts/autoupdate.sh
+++ b/scripts/autoupdate.sh
@@ -17,6 +17,10 @@ wget -P /tmp https://ghproxy.com/https://raw.githubusercontent.com/klever1988/na
 chmod +x /tmp/truncate /tmp/ddnz
 
 board_id=$(cat /etc/board.json | jsonfilter -e '@["model"].id' | sed 's/friendly.*,nanopi-//;s/xunlong,orangepi-//;s/^r1s-h5$/r1s/;s/^r1$/r1s-h3/;s/^r1-plus$/r1p/')
+if [[ $board_id =~ .*qemu.* ]]; then
+    echo -e '\e[91m当前环境为qemu虚拟机，默认下载x86固件\e[0m'
+    board_id=x86
+fi
 mount -t tmpfs -o remount,size=850m tmpfs /tmp
 rm -rf /tmp/upg && mkdir /tmp/upg && cd /tmp/upg
 set +e


### PR DESCRIPTION
因为现在很多用户都是虚拟机双软路由，所以基本都是qemu虚拟机，将识别为“qemu”机型，而不能下载更新
<img width="1095" alt="iShot2021-07-30 00 06 36" src="https://user-images.githubusercontent.com/33802186/127530021-40a8bcd9-68fc-4a67-ab8c-3a3de3065db7.png">
