### PR TITLE
[l2tp] add softwares for l2tp

### DIFF
--- a/r2s.config.seed
+++ b/r2s.config.seed
@@ -24,6 +24,8 @@ CONFIG_PACKAGE_luci-theme-openwrt-2020=y
 CONFIG_PACKAGE_collectd-mod-ping=y
 CONFIG_PACKAGE_collectd-mod-thermal=y
 
+CONFIG_PACKAGE_xl2tpd=y
+CONFIG_PACKAGE_ppp-mod-pppol2tp=y
 
 CONFIG_PACKAGE_kmod-drm-rockchip=y
 CONFIG_PACKAGE_kmod-gpu-lima=y


### PR DESCRIPTION
Add 2 packages supporting l2tp: `xl2tpd` and `pppol2tp`. These two softwares are required to config an l2tp auth. The default package source cannot provide the right version of these two packges.